### PR TITLE
[change]カート内に商品追加機能、カート内商品編集画面バグの修正

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -23,9 +23,9 @@
                   <%= cart_item.item.name %>
                 </td>
                 <td><%= cart_item.item.with_tax_price %></td>
-                <td>
-                  <%= form_with model: cart_item,url:cart_item_path(cart_item.id), method: :patch, local:true do |f| %> 
-                  <%= f.select :amount,(1..10).to_a, selected: cart_item.amount, class: "form-select form-select-sm" %>
+                <td class ="row">
+                  <%= form_with model: cart_item,url:cart_item_path(cart_item.id), method: :patch, local:true ,class: "d-flex align-items-center" do |f| %> 
+                  <%= f.number_field :amount, min: 1, selected: cart_item.amount,class: "form-control form-control-sm" %>
                   <%= f.submit "変更", class: "btn btn-success btn-sm" %>
                   <% end %>
                 </td>
@@ -41,7 +41,7 @@
         <div>
           <%= link_to "買い物を続ける", root_path, class: "btn btn-primary" %>
         </div>
-        <table class ="table">
+        <table class ="table col=2">
           <tr>
             <th>合計金額</th>
             <td>
@@ -50,9 +50,12 @@
           </tr>
         </table>
       </div>
-      <div class ="text-center">
-        <%= link_to "情報入力に進む" ,new_order_path, class: "btn btn-success" %>
-      </div>
+      <% if @cart_items.present? %>
+        <div class ="text-center">
+          <%= link_to "情報入力に進む" ,new_order_path, class: "btn btn-success" %>
+        </div>
+      <% else %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -3,6 +3,6 @@ show
 
 <%= form_with model: @cart_item_new,url: cart_items_path, method: :post, local:true do |f| %>
   <%= f.hidden_field :item_id, value: @item.id %>
-  <%= f.select :amount, *[1..10] %>
+  <%= f.number_field :amount, min: 1, placeholder: '個数選択',class: "form-control form-control-sm" %>
   <%= f.submit "カートに入れる",class: "btn btn-success" %>
 <% end %>


### PR DESCRIPTION
- item showページ個数入力画面に、個数選択のplaceholder追加。個数制限を解除。
- cart_item indexページ 個数変更欄の個数制限を解除。
- カートアイテムないのに情報入力に進めてしまうバグを解除。（カートアイテムない状態ではボタンを非表示にするよう変更)