### PR TITLE
[change]admin order index　注文個数を合計個数で表示するようにした

### DIFF
--- a/app/views/admin/homes/index.erb
+++ b/app/views/admin/homes/index.erb
@@ -21,9 +21,7 @@
             </td>
             <td><%= full_name(order.customer) %></td>
             <td>
-              <%# order.order_details.each do |order_detail| %>
               <%= number_with_delimiter(order.order_details.sum(&:amount)) %>
-              <%# end %>
             </td>
             <td><%= order.status %></td>
           </tr>

--- a/app/views/admin/homes/index.erb
+++ b/app/views/admin/homes/index.erb
@@ -21,9 +21,9 @@
             </td>
             <td><%= full_name(order.customer) %></td>
             <td>
-              <% order.order_details.each do |order_detail| %>
-              <%= number_with_delimiter(order_detail.amount) %>
-              <% end %>
+              <%# order.order_details.each do |order_detail| %>
+              <%= number_with_delimiter(order.order_details.sum(&:amount)) %>
+              <%# end %>
             </td>
             <td><%= order.status %></td>
           </tr>


### PR DESCRIPTION
- admin order index 会員側　注文履歴一覧（トップ）画面　注文個数を１回の注文に対する合計個数で表示するようにした