### PR TITLE
Matsuda feature function admin/statusupdate

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -2,6 +2,19 @@ class Admin::OrderDetailsController < ApplicationController
   before_action :authenticate_admin!
   
   def update
+    order_detail = OrderDetail.find(params[:id])
+
+    if order_detail.update(order_detail_params)
+      redirect_to admin_order_path(order_detail.order), notice: '注文ステータスが更新されました。'
+    else
+      render :index, alert: 'ステータスの更新に失敗しました。'
+    end
+  end
+
+  private
+
+  def order_detail_params
+    params.require(:order_detail).permit(:making_status)
   end
 
 end

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -5,9 +5,9 @@ class Admin::OrderDetailsController < ApplicationController
     order_detail = OrderDetail.find(params[:id])
 
     if order_detail.update(order_detail_params)
-      redirect_to admin_order_path(order_detail.order), notice: '注文ステータスが更新されました。'
+      redirect_to admin_order_path(order_detail.order) #notice: '注文ステータスが更新されました。'
     else
-      render :index, alert: 'ステータスの更新に失敗しました。'
+      render :index #alert: 'ステータスの更新に失敗しました。'
     end
   end
 

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -7,7 +7,7 @@ class Admin::OrderDetailsController < ApplicationController
     if order_detail.update(order_detail_params)
       redirect_to admin_order_path(order_detail.order) #notice: '注文ステータスが更新されました。'
     else
-      render :index #alert: 'ステータスの更新に失敗しました。'
+      redirect_to admin_order_path(order_detail.order) #alert: 'ステータスの更新に失敗しました。'
     end
   end
 

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -4,7 +4,20 @@ class Admin::OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
+
   def update
+    @order = Order.find(params[:id])
+    
+    if @order.update(order_params)
+      redirect_to admin_order_path(@order) #notice: '注文ステータスが更新されました。'
+    else
+      render :index #alert: 'ステータスの更新に失敗しました。'
+    end
   end
-  
+
+  private
+
+  def order_params
+    params.require(:order).permit(:status)
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,7 +11,7 @@ class Admin::OrdersController < ApplicationController
     if @order.update(order_params)
       redirect_to admin_order_path(@order) #notice: '注文ステータスが更新されました。'
     else
-      render :index #alert: 'ステータスの更新に失敗しました。'
+      redirect_to admin_order_path(@order)  #alert: 'ステータスの更新に失敗しました。'
     end
   end
 

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -57,7 +57,7 @@
             <td><%= number_with_delimiter(order_detail.amount) %></td>
             <td><%= number_with_delimiter(order_detail.amount * order_detail.price) %></td>
             <td>
-              <%= form_with model:order_detail, url: admin_order_detail_path, method: :patch, class: "d-flex align-items-center" do |f| %>
+              <%= form_with model:order_detail, url: admin_order_detail_path(order_detail), method: :patch, class: "d-flex align-items-center" do |f| %>
                 <%= f.select :making_status,  OrderDetail.making_statuses.keys.map { |key| [key, key] }, { selected: order_detail.making_status }, class: "form-control form-control-sm me-2 w-auto"%>
               <%= f.submit '更新' ,class:"ml-3 btn btn-success" %>
             <% end %>


### PR DESCRIPTION
- admin order show 会員側注文履歴詳細画面のステータス更新機能追加
- admin order show 製作ステータス更新フォームのid記述漏れのため追加
- 更新失敗時のリダイレクト先を元の画面にした
- フラッシュメッセージは、別ブランチで実装するため、一度コメントアウトす