### PR TITLE
[add]注文ステータスと製作ステータスの紐づけ

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -3,11 +3,40 @@ class Admin::OrderDetailsController < ApplicationController
   
   def update
     order_detail = OrderDetail.find(params[:id])
+    order = order_detail.order
 
+    if params[:order_detail][:making_status] == "着手不可" 
+      redirect_to request.referer,alert: 'こちらは手動で変えられません。'
+      return
+    end
+
+    if params[:order_detail][:making_status] == "製作待ち" 
+      redirect_to request.referer,alert: 'こちらは手動で変えられません。'
+      return
+    end
+    
     if order_detail.update(order_detail_params)
-      redirect_to admin_order_path(order_detail.order) ,notice: '製作ステータスが更新されました。'
+
+      if params[:order_detail][:making_status] == "製作中" 
+        if order.status == "製作中"
+          redirect_to request.referer,notice: '製作ステータスが製作中に更新されました。'
+        else
+          order.update(status: 2)
+          order.reload
+          redirect_to request.referer,notice: '製作ステータスが製作中に更新されました。注文ステータスが製作中になりました。'
+        end
+      end
+
+      if params[:order_detail][:making_status] == "製作完了"
+        if is_all_order_details_making_completed(order)
+          order_detail.order.update(status:3)
+          redirect_to request.referer,notice: '製作ステータスは、全て製作完了になりました。注文ステータスが発送準備中になりました。'
+        else
+          redirect_to request.referer,notice: '製作が製作完了に更新されましたが、すべての製作は完了しておりません。'
+        end
+      end
     else
-      redirect_to admin_order_path(order_detail.order) ,alert: '製作ステータスの更新に失敗しました。'
+      redirect_to request.referer,alert: '製作ステータスの更新に失敗しました。'
     end
   end
 
@@ -16,5 +45,14 @@ class Admin::OrderDetailsController < ApplicationController
   def order_detail_params
     params.require(:order_detail).permit(:making_status)
   end
+
+  def is_all_order_details_making_completed(order)
+    #order.order_details.each do |order_detail|
+      #order_detail.making_status != "製作完了"
+      unless order.order_details.all? { |order_detail| order_detail.making_status == "製作完了" }
+        return false 
+      end
+    return true 
+  end  
 
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -7,13 +7,45 @@ class Admin::OrdersController < ApplicationController
 
   def update
     @order = Order.find(params[:id])
-    
-    if @order.update(order_params)
+
+    if params[:order][:status] == "入金待ち"
+      @order.update(order_params)
       redirect_to admin_order_path(@order) ,notice: '注文ステータスが更新されました。'
-    else
-      redirect_to admin_order_path(@order) ,alert: '注文ステータスの更新に失敗しました。'
+      return
     end
+
+    if params[:order][:status] == "入金確認"
+      @order.update(order_params)
+      @order.order_details.update_all(making_status:1)
+      redirect_to admin_order_path(@order) ,notice: '注文ステータスが更新されました。製作ステータスが製作待ちになりました。'
+      return
+    end
+
+    if params[:order][:status] == "製作中"
+      redirect_to admin_order_path(@order) ,alert: 'こちらは手動で変えられません。製作ステータスが更新されるまでお待ちください。'
+      return
+    end
+
+    if params[:order][:status] == "発送準備中"
+      redirect_to admin_order_path(@order) ,alert: 'こちらは手動で変えられません。製作ステータスが全て製作完了になるまでお待ちください'
+      return
+    end
+
+    if params[:order][:status] == "発送済み"
+      if @order.order_details.all? { |order_detail| order_detail.making_status == "製作完了" }
+        order_detail.making_status == "製作完了"
+        @order.update(order_params)
+        redirect_to admin_order_path(@order) ,notice: '注文ステータスが更新されました。発送済みになりました。'
+      else
+        redirect_to admin_order_path(@order) ,alert: '製作ステータスが全て製作完了になるまでお待ちください。'
+        return
+      end
+    end
+
+    redirect_to admin_order_path(@order), alert: '注文ステータスの更新に失敗しました。'
+    
   end
+
 
   private
 

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -57,9 +57,17 @@
             <td><%= number_with_delimiter(order_detail.amount) %></td>
             <td><%= number_with_delimiter(order_detail.amount * order_detail.price) %></td>
             <td>
-              <%= form_with model:order_detail, url: admin_order_detail_path(order_detail), method: :patch, class: "d-flex align-items-center" do |f| %>
-                <%= f.select :making_status,  OrderDetail.making_statuses.keys.map { |key| [key, key] }, { selected: order_detail.making_status }, class: "form-control form-control-sm mr-2 w-75 text-center"%>
-              <%= f.submit '更新' ,class:"ml-3 btn btn-success" %>
+            <%= form_with model:order_detail, url: admin_order_detail_path(order_detail), method: :patch, class: "d-flex align-items-center" do |f| %>
+              <% if order_detail.order.status == 0 %>
+                <%= f.select :making_status, OrderDetail.making_statuses.keys.map { |key| [key, key] }, { selected: "着手不可", disabled: true }, class: "form-control form-control-sm mr-2 w-75 text-center" %>
+              <% else %>
+                <%= f.select :making_status, OrderDetail.making_statuses.keys.map { |key| [key, key] }, { selected: order_detail.making_status }, class: "form-control form-control-sm mr-2 w-75 text-center" %>
+              <% end %>
+
+              <%#= form_with model:order_detail, url: admin_order_detail_path(order_detail), method: :patch, class: "d-flex align-items-center" do |f| %>
+                <%#= f.select :making_status,  OrderDetail.making_statuses.keys.map { |key| [key, key] }, { selected: order_detail.making_status }, class: "form-control form-control-sm mr-2 w-75 text-center"%>
+              <%#= f.submit '更新' ,class:"ml-3 btn btn-success" %>
+              <%= f.submit '更新', class: "ml-3 btn btn-success" %>
             <% end %>
             </td>
           </tr>


### PR DESCRIPTION
-orderの注文ステータスとorder_detailの製作ステータス　紐づけ。

＜要件定義内＞　
　- 注文が入金確認に更新すると、製作すべてが製作待ちになる
　- 製作が１つでも製作中に更新されれば、注文が製作中になる
　- 製作が全て製作完了になると、注文が発送準備中になる

＜要件定義外　誤作動防止＞
- 注文ステータス
　- 製作中、発送準備中は手動で更新できないようにした。
　- 商品が製作完了していないときに、発送済みにできないようにした。
- 製作ステータス
　- 着手不可に戻せないようにした。
　- 製作待ちを手動で変えられないようにした。
- 各種　notice alert文の追加